### PR TITLE
Add serialization to Well Known Text/Binary formats for `Geo::Coord`

### DIFF
--- a/spec/geo/coord_spec.cr
+++ b/spec/geo/coord_spec.cr
@@ -121,6 +121,21 @@ describe Geo::Coord do
     end
   end
 
+  describe "#to_wkb" do
+    it "generates a Well Known Binary format" do
+      coord = Geo::Coord.new(12, 34)
+
+      ewkb = coord.to_wkb
+
+      ewkb.should eq Bytes[
+        0,                       # Big-Endian
+        0, 0, 0, 1,              # POINT
+        0, 0, 0, 34, 0, 0, 0, 0, # Longitude encoded as IEEE-754
+        0, 0, 0, 12, 0, 0, 0, 0, # Latitude encoded as IEEE-754
+      ]
+    end
+  end
+
   describe "#to_ewkt" do
     it "generates an Extended Well Known Text format" do
       coord = Geo::Coord.new(50.004444, 36.231389)

--- a/spec/geo/coord_spec.cr
+++ b/spec/geo/coord_spec.cr
@@ -111,6 +111,32 @@ describe Geo::Coord do
     geojson.should be_a(GeoJSON::Coordinates)
   end
 
+  describe "#to_ewkt" do
+    it "generates an Extended Well Known Text format" do
+      coord = Geo::Coord.new(50.004444, 36.231389)
+
+      ewkt = coord.to_ewkt
+
+      ewkt.should eq "SRID=4326;POINT(36.231389 50.004444)"
+    end
+  end
+
+  describe "#to_ewkb" do
+    it "generates an Extended Well Known Binary format" do
+      coord = Geo::Coord.new(12, 34)
+
+      ewkb = coord.to_ewkb
+
+      ewkb.should eq Bytes[
+        0,                       # Big-Endian
+        0, 0, 0, 1,              # POINT
+        0, 0, 0, 34, 0, 0, 0, 0, # Longitude encoded as IEEE-754
+        0, 0, 0, 12, 0, 0, 0, 0, # Latitude encoded as IEEE-754
+        16, 140,                 # SRID 4326
+      ]
+    end
+  end
+
   describe "comparisons" do
     describe "equality" do
       pos1 = Geo::Coord.new(45.3142533036254, -93.47527313511819)

--- a/spec/geo/coord_spec.cr
+++ b/spec/geo/coord_spec.cr
@@ -111,6 +111,16 @@ describe Geo::Coord do
     geojson.should be_a(GeoJSON::Coordinates)
   end
 
+  describe "#to_wkt" do
+    it "generates a Well Known Text format" do
+      coord = Geo::Coord.new(50.004444, 36.231389)
+
+      ewkt = coord.to_wkt
+
+      ewkt.should eq "POINT(36.231389 50.004444)"
+    end
+  end
+
   describe "#to_ewkt" do
     it "generates an Extended Well Known Text format" do
       coord = Geo::Coord.new(50.004444, 36.231389)

--- a/spec/geo/polygon_spec.cr
+++ b/spec/geo/polygon_spec.cr
@@ -119,6 +119,19 @@ describe Geo::Polygon do
     geojson.should be_a(GeoJSON::Polygon)
   end
 
+  describe "#to_wkt" do
+    it "outputs a Well Known Text format" do
+      polygon = Geo::Polygon.new([
+        Geo::Coord.new(10, 30),
+        Geo::Coord.new(20, 10),
+        Geo::Coord.new(40, 20),
+        Geo::Coord.new(40, 40),
+      ])
+
+      polygon.to_wkt.should eq "POLYGON((30 10, 10 20, 20 40, 40 40, 30 10))"
+    end
+  end
+
   describe "comparisons" do
     describe "equality" do
       polygon1 = Geo::Polygon.new([pos1, pos2])

--- a/src/geo/coord.cr
+++ b/src/geo/coord.cr
@@ -174,11 +174,11 @@ module Geo
       String.build { |str| to_ewkt str }
     end
 
-    def to_ewkt(io : IO) : Nil
+    def to_ewkt(io : IO, output_type = true, output_parentheses = true) : Nil
       # SRID 4326 is used for latitude and longitude
       # https://epsg.org/crs_4326/WGS-84.html
       io << "SRID=4326;"
-      to_wkt io
+      to_wkt io, output_type: output_type, output_parentheses: output_parentheses
     end
 
     def to_ewkb(bytes : Bytes = Bytes.new(23), byte_format : IO::ByteFormat = IO::ByteFormat::BigEndian) : Bytes
@@ -194,10 +194,11 @@ module Geo
       String.build { |str| to_wkt str }
     end
 
-    def to_wkt(io : IO) : Nil
-      io << "POINT("
+    def to_wkt(io : IO, output_type = true, output_parentheses = true) : Nil
+      io << "POINT" if output_type
+      io << '(' if output_parentheses
       io << lng << ' ' << lat
-      io << ')'
+      io << ')' if output_parentheses
     end
 
     def to_wkb(bytes : Bytes = Bytes.new(21), byte_format : IO::ByteFormat = IO::ByteFormat::BigEndian) : Bytes

--- a/src/geo/coord.cr
+++ b/src/geo/coord.cr
@@ -181,17 +181,11 @@ module Geo
       to_wkt io
     end
 
-    def to_ewkb : Bytes
-      endian = IO::ByteFormat::BigEndian
-
-      bytes = Bytes.new(23)
-      bytes[0] = 0                  # Big Endian
-      endian.encode 1u32, bytes + 1 # POINT type
-      endian.encode lng, bytes + 5
-      endian.encode lat, bytes + 13
+    def to_ewkb(bytes : Bytes = Bytes.new(23), byte_format : IO::ByteFormat = IO::ByteFormat::BigEndian) : Bytes
+      to_wkb bytes, byte_format
       # SRID 4326 is used for latitude and longitude
       # https://epsg.org/crs_4326/WGS-84.html
-      endian.encode 4236i16, bytes + 21
+      byte_format.encode 4236i16, bytes + 21
 
       bytes
     end
@@ -204,6 +198,15 @@ module Geo
       io << "POINT("
       io << lng << ' ' << lat
       io << ')'
+    end
+
+    def to_wkb(bytes : Bytes = Bytes.new(21), byte_format : IO::ByteFormat = IO::ByteFormat::BigEndian) : Bytes
+      bytes[0] = 0                  # Big Endian
+      byte_format.encode 1u32, bytes + 1 # POINT type
+      byte_format.encode lng, bytes + 5
+      byte_format.encode lat, bytes + 13
+
+      bytes
     end
 
     def ll

--- a/src/geo/coord.cr
+++ b/src/geo/coord.cr
@@ -177,9 +177,8 @@ module Geo
     def to_ewkt(io : IO) : Nil
       # SRID 4326 is used for latitude and longitude
       # https://epsg.org/crs_4326/WGS-84.html
-      io << "SRID=4326;POINT("
-      io << lng << ' ' << lat
-      io << ')'
+      io << "SRID=4326;"
+      to_wkt io
     end
 
     def to_ewkb : Bytes
@@ -195,6 +194,16 @@ module Geo
       endian.encode 4236i16, bytes + 21
 
       bytes
+    end
+
+    def to_wkt : String
+      String.build { |str| to_wkt str }
+    end
+
+    def to_wkt(io : IO) : Nil
+      io << "POINT("
+      io << lng << ' ' << lat
+      io << ')'
     end
 
     def ll

--- a/src/geo/coord.cr
+++ b/src/geo/coord.cr
@@ -170,6 +170,33 @@ module Geo
       io << strfcoord(%{%latd°%latm'%lats"%lath %lngd°%lngm'%lngs"%lngh})
     end
 
+    def to_ewkt : String
+      String.build { |str| to_ewkt str }
+    end
+
+    def to_ewkt(io : IO) : Nil
+      # SRID 4326 is used for latitude and longitude
+      # https://epsg.org/crs_4326/WGS-84.html
+      io << "SRID=4326;POINT("
+      io << lng << ' ' << lat
+      io << ')'
+    end
+
+    def to_ewkb : Bytes
+      endian = IO::ByteFormat::BigEndian
+
+      bytes = Bytes.new(23)
+      bytes[0] = 0                  # Big Endian
+      endian.encode 1u32, bytes + 1 # POINT type
+      endian.encode lng, bytes + 5
+      endian.encode lat, bytes + 13
+      # SRID 4326 is used for latitude and longitude
+      # https://epsg.org/crs_4326/WGS-84.html
+      endian.encode 4236i16, bytes + 21
+
+      bytes
+    end
+
     def ll
       {lat, lng}
     end

--- a/src/geo/polygon.cr
+++ b/src/geo/polygon.cr
@@ -106,6 +106,21 @@ module Geo
       GeoJSON::Polygon.new([coordinates])
     end
 
+    def to_wkt : String
+      String.build { |str| to_wkt str }
+    end
+
+    def to_wkt(io : IO) : Nil
+      io << "POLYGON(("
+      @coords.each_with_index 1 do |coord, index|
+        coord.to_wkt io, output_type: false, output_parentheses: false
+        if index < @coords.size
+          io << ", "
+        end
+      end
+      io << "))"
+    end
+
     private def calculate_centroid : Geo::Coord
       centroid_lat = 0.0
       centroid_lng = 0.0


### PR DESCRIPTION
This PR adds [WKT, WKB, EWKT, and EWKB](https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry#Format_variations) serialization formats for `Geo::Coord`. These formats are understood by various databases like [PostGIS's `GEOGRAPHY` type](https://postgis.net/docs/using_postgis_dbmanagement.html#PostGIS_Geography) (which understands pretty much any format you throw at it) and [Elasticsearch's `geo_point` type](https://www.elastic.co/guide/en/elasticsearch/reference/current/geo-point.html) (which understands WKT).

Since `Geo::Coord` is all about latitude and longitude, we can assume it uses SRID 4326 and only deals with `POINT` types. I also set `Geo::Polygon` to specifically deal with `POLYGON` types for WKT.

Ideally `Geo::Coord` would also be able to _parse_ these formats, as well, but that's more difficult, at least for the text formats without using regexes and would need to handle parsing errors reasonably. So I just wanted to get this functionality up here first.

This PR also adds WKT format for `Geo::Polygon` mostly as an example of how we can integrate serialization of composite types. EWKT will be basically the same thing with the `SRID=4326;` prefix and WKB/EWKB will need to calculate the number of bytes. I wasn't prepared to do all that at the moment, but the groundwork is (mostly?) there for it.